### PR TITLE
MIN and MAX now take a 'token' instead of a field name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fergies-inverted-index",
-  "version": "5.5.0",
+  "version": "6.0.0",
   "description": "An inverted index that allows javascript objects to be easily serialised and retrieved using promises and map-reduce",
   "main": "dist/fergies-inverted-index.cjs.js",
   "module": "dist/fergies-inverted-index.esm.js",

--- a/src/read.js
+++ b/src/read.js
@@ -208,13 +208,13 @@ export default function init (db, ops) {
 
   const MAX = fieldName => BOUNDING_VALUE(fieldName, true)
 
-  const BOUNDING_VALUE = (fieldName, reverse) => parseToken({
-    FIELD: [fieldName]
-  }).then(token => Object.assign(token, {
-    LIMIT: 1,
-    REVERSE: reverse
-  })).then(
-    RANGE
+  const BOUNDING_VALUE = (token, reverse) => parseToken(
+    token
+  ).then(
+    token => RANGE(Object.assign(token, {
+      LIMIT: 1,
+      REVERSE: reverse
+    }))
   ).then(
     max => max.pop()._match.pop().split(':').pop().split('#').shift()
   )

--- a/test/cjs/aggregation-test.js
+++ b/test/cjs/aggregation-test.js
@@ -216,13 +216,13 @@ function init (db, ops) {
 
   const MAX = fieldName => BOUNDING_VALUE(fieldName, true);
 
-  const BOUNDING_VALUE = (fieldName, reverse) => parseToken({
-    FIELD: [fieldName]
-  }).then(token => Object.assign(token, {
-    LIMIT: 1,
-    REVERSE: reverse
-  })).then(
-    RANGE
+  const BOUNDING_VALUE = (token, reverse) => parseToken(
+    token
+  ).then(
+    token => RANGE(Object.assign(token, {
+      LIMIT: 1,
+      REVERSE: reverse
+    }))
   ).then(
     max => max.pop()._match.pop().split(':').pop().split('#').shift()
   );

--- a/test/src/MAX-MIN-test.js
+++ b/test/src/MAX-MIN-test.js
@@ -112,28 +112,40 @@ test('can add some data', t => {
 
 test('get MAX value for one field', t => {
   t.plan(1)
-  global[indexName].MAX('price').then(
+  global[indexName].MAX({ FIELD: [ 'price' ] }).then(
     result => t.equals(result, '88652')
+  )
+})
+
+test('get MAX value for one field', t => {
+  t.plan(1)
+  global[indexName].MAX({
+    FIELD: [ 'price' ],
+    VALUE: {
+      LTE: '5'
+    }
+  }).then(
+    result => t.equals(result, '57280')
   )
 })
 
 test('get MIN value for one field', t => {
   t.plan(1)
-  global[indexName].MIN('price').then(
+  global[indexName].MIN({ FIELD: [ 'price' ] }).then(
     result => t.equals(result, '33114')
   )
 })
 
 test('get MAX value for one field containing a comment', t => {
   t.plan(1)
-  global[indexName].MAX('year').then(
+  global[indexName].MAX({ FIELD: [ 'year' ] }).then(
     result => t.equals(result, '2019')
   )
 })
 
 test('get MIN value for one field containing a comment', t => {
   t.plan(1)
-  global[indexName].MIN('year').then(
+  global[indexName].MIN({ FIELD: [ 'year' ] }).then(
     result => t.equals(result, '2000')
   )
 })

--- a/test/src/query-parser-test.js
+++ b/test/src/query-parser-test.js
@@ -263,7 +263,7 @@ test('can do AND with embedded OR search', t => {
 
 test('can get highest VALUE of totalamt (MAX)', t => {
   t.plan(1)
-  global[indexName].MAX('totalamt')
+  global[indexName].MAX({ FIELD: 'totalamt' })
    .then(result => {
      t.equal(result, '6060000')
    })
@@ -271,7 +271,7 @@ test('can get highest VALUE of totalamt (MAX)', t => {
 
 test('can get lowest VALUE of totalamt (MIN)', t => {
   t.plan(1)
-  global[indexName].MIN('totalamt')
+  global[indexName].MIN({ FIELD: 'totalamt' })
    .then(result => {
      t.equal(result, '0')
    })


### PR DESCRIPTION
and version bump to 6.x.x