### PR TITLE
account for occasions where token VALUE contains a ':'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "fergies-inverted-index",
-  "version": "10.0.4",
+  "version": "10.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.0.4",
+      "version": "10.0.6",
       "license": "MIT",
       "dependencies": {
         "charwise": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fergies-inverted-index",
-  "version": "10.0.5",
+  "version": "10.0.6",
   "description": "An inverted index that allows javascript objects to be easily serialised and retrieved using promises and map-reduce",
   "browser": "src/browser.js",
   "main": "src/node.js",

--- a/src/parseToken.js
+++ b/src/parseToken.js
@@ -18,9 +18,19 @@ module.exports = (token, availableFields) =>
     if (typeof token === 'undefined') token = {}
 
     if (typeof token === 'string') {
-      const fieldValue = token.split(':')
-      const value = fieldValue.pop()
-      const field = fieldValue.pop()
+      // Find the first occurrence of ':'. Anything thereafter should be considered
+      // a part of the value. This accounts for occasions where the value itself
+      // has a ':'.
+      const delimiterIdx = token.indexOf(':')
+      let value, field
+
+      if (delimiterIdx !== -1) {
+        field = token.slice(0, delimiterIdx)
+        value = token.slice(delimiterIdx + 1)
+      } else {
+        value = token
+      }
+
       if (field) {
         return resolve({
           FIELD: [field],

--- a/test/src/parseToken-test.js
+++ b/test/src/parseToken-test.js
@@ -136,6 +136,19 @@ test('can parse a token of the format "<FIELD>:<VALUE>"', t => {
   )
 })
 
+test('can parse a token of the format "<FIELD>:<VALUE> where <VALUE> has a :"', t => {
+  t.plan(1)
+  global[indexName].parseToken('make:vol:vo').then(result =>
+    t.deepEqual(result, {
+      FIELD: ['make'],
+      VALUE: {
+        GTE: 'vol:vo',
+        LTE: 'vol:vo'
+      }
+    })
+  )
+})
+
 test('can parse a token of the format { FIELD: <field name> }', t => {
   t.plan(1)
   global[indexName].parseToken({ FIELD: 'make' }).then(result =>


### PR DESCRIPTION
addresses #40 