### PR TITLE
fix: remove `os-browserify` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fergies-inverted-index",
-  "version": "10.0.6",
+  "version": "10.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fergies-inverted-index",
-      "version": "10.0.6",
+      "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
         "browser-level": "^1.0.1",
@@ -20,7 +20,6 @@
         "buffer": "^6.0.3",
         "diacritic": "^0.0.2",
         "memory-level": "^1.0.0",
-        "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "standard": "^16.0.4",
@@ -4031,12 +4030,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ordered-emitter/-/ordered-emitter-0.1.1.tgz",
       "integrity": "sha1-qiC9r73MFjGDSjUPaLTvjrNO7Xs=",
-      "dev": true
-    },
-    "node_modules/os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true
     },
     "node_modules/p-cancelable": {
@@ -9279,12 +9272,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ordered-emitter/-/ordered-emitter-0.1.1.tgz",
       "integrity": "sha1-qiC9r73MFjGDSjUPaLTvjrNO7Xs=",
-      "dev": true
-    },
-    "os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true
     },
     "p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "buffer": "^6.0.3",
     "diacritic": "^0.0.2",
     "memory-level": "^1.0.0",
-    "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "standard": "^16.0.4",

--- a/test/src/memory-level-test.js
+++ b/test/src/memory-level-test.js
@@ -1,4 +1,4 @@
-const fii = require('../../src/node')
+const fii = require('../../src/main')
 const { MemoryLevel } = require('memory-level')
 const test = require('tape')
 const wbd = require('world-bank-dataset')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,8 +24,7 @@ const config = {
       "fs": false,
       "path": require.resolve("path-browserify"),
       "stream": require.resolve("stream-browserify"),
-      'util': false,
-      "os": require.resolve("os-browserify")
+      'util': false
     }
   }
 }


### PR DESCRIPTION
The `abstract-level` PR added a new dependency on `os-browserify` - this was triggered by importing `fii` from `src/node` instead of `src/main` in the `memory-level-test.js`. This PR fixes this and removes the `os-browserify` dependency.